### PR TITLE
Improvements to get what contracts can be verifyed 

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -6,7 +6,7 @@ const API_URLS = {
 
 const BLOCKSCOUT_URLS = {
   1: 'https://blockscout.com/eth/mainnet/',
-  // 1101: 'https://integration-blockscout.celo-testnet.org/api'
+  // 1101: 'https://integration-blockscout.celo-testnet.org'
   1101: 'http://localhost:4000'
 }
 
@@ -20,7 +20,8 @@ const VerificationStatus = {
   NOT_VERIFIED: 'Fail - Unable to verify',
   SUCCESS: 'Pass - Verified',
   PENDING: 'Pending in queue',
-  ALREADY_VERIFIED: 'Contract source code already verified'
+  ALREADY_VERIFIED: 'Contract source code already verified',
+  NOT_DEPLOYED: 'Contract not deployed in the network'
 }
 
 module.exports = {

--- a/util.js
+++ b/util.js
@@ -7,12 +7,21 @@ const enforce = (condition, message, code) => {
   if (!condition) abort(message, code)
 }
 
-const enforceOrThrow = (condition, message) => {
+const enforceOrThrowError = (condition, message) => {
   if (!condition) throw new Error(message)
+}
+
+const enforceOrThrowWarn = (condition, message) => {
+  if (!condition) {
+    console.warn(message)
+    return false
+  }
+  return true
 }
 
 module.exports = {
   abort,
   enforce,
-  enforceOrThrow
+  enforceOrThrowError,
+  enforceOrThrowWarn
 }

--- a/verify.js
+++ b/verify.js
@@ -11,7 +11,7 @@ const kit = newKit('http://localhost:8545')
 
 module.exports = async (config) => {
   const options = parseConfig(config)
-  //const kit = newKit.getExchange('http://localhost:8545')
+  // const kit = newKit.getExchange('http://localhost:8545')
   // Verify each contract
   contractNames = config._.slice(1)
 
@@ -55,18 +55,18 @@ module.exports = async (config) => {
           status += `: ${explorerUrl}`
           deployedContracts.push(contractName)
         }
-        console.log(status)
+        console.debug(status)
       }
       
     } catch (e) {
       console.error(`Error ${e}`)
       failedContracts.push(contractName)
     }
-    console.log()
+    console.debug()
   }
 
-  console.log(`\r\nContracts not deployed: ${notDeployedContracts.join(', ')}\r\n`)
-  console.log(`\r\nSuccessfully verified ${deployedContracts.length} contract(s).\r\n`)
+  console.info(`\r\nContracts not deployed: ${notDeployedContracts.join(', ')}\r\n`)
+  console.info(`\r\nSuccessfully verified ${deployedContracts.length} contract(s).\r\n`)
 
   enforceOrThrowError(
     failedContracts.length === 0,
@@ -100,7 +100,6 @@ const parseConfig = (config) => {
   if (optimizerSettings.enabled == 1) {
     optimization = true
   }
-  //console.debug(`Optimization Used {optimizerSettings.enabled} - Opt = ${optimization}`)
 
   return {
     blockscoutUrl,
@@ -171,8 +170,6 @@ const sendVerifyRequest = async (artifact, options) => {
 
   const verifyUrl = `${options.apiUrl}?module=contract&action=verify`
   try {
-    // console.log(`verifyUrl: ${verifyUrl}`)
-    // console.log(`postQueries: ${JSON.stringify(postQueries, null, 4)}`)
     return axios.post(verifyUrl, postQueries)
   } catch (e) {
     console.error(`Error verifying: ${e}`)


### PR DESCRIPTION
Only try to verify the contracts that the abi has the key `.networks[networkId].address` and also do not include those contracts to the failed list (because they are not deployed).
Some other minor refactor.